### PR TITLE
SUP-2258: Benqi Staking extended with withdraw following cooldown period

### DIFF
--- a/src/benqi/BenqiERC4626Staking.sol
+++ b/src/benqi/BenqiERC4626Staking.sol
@@ -59,9 +59,17 @@ contract BenqiERC4626Staking is ERC4626 {
     IStakedAvax public sAVAX;
     IWETH public wavax;
     ERC20 public sAvaxAsset;
+    ERC20 public wsAVAX;
+
+    uint256 requestId;
 
     /// @dev Mapping used by this contract, not sAvax. User on Avax can wish to request multiple unlocks
-    mapping(address => UnlockRequest[]) public requests;
+    /// TODO: Significant gas savings & logic reduction if we only allow single UnlockRequest. Tradeoff.
+    mapping(address owner => UnlockRequest[]) public requests;
+
+    /// @dev Mapping used by this contract, not sAvax. User on Avax can wish to give allowance to unlock
+    /// TODO: This is mass-allowance, for all of the requests. To avoid looping. 
+    mapping(address owner => mapping(address spender => uint256 allowed)) public requestsAllowed;
 
     /*//////////////////////////////////////////////////////////////
                             CONSTRUCTOR
@@ -71,7 +79,7 @@ contract BenqiERC4626Staking is ERC4626 {
     /// @param sAvax_ sAVAX (Benqi staking contract) address
     constructor(address wavax_, address sAvax_)
         // address tradeJoePool_
-        ERC4626(ERC20(wavax_), "ERC4626-Wrapped sAVAX", "wLsAVAX")
+        ERC4626(ERC20(wavax_), "ERC4626-Wrapped sAVAX", "wsAVAX")
     {
         sAVAX = IStakedAvax(sAvax_);
         sAvaxAsset = ERC20(sAvax_);
@@ -85,10 +93,17 @@ contract BenqiERC4626Staking is ERC4626 {
     //////////////////////////////////////////////////////////////*/
 
     struct UnlockRequest {
+        /// @dev Unique id of the request (Wrapper specific)
+        uint id;
         // The timestamp at which the `shareAmount` was requested to be unlocked
         uint startedAt;
         // The amount of shares to burn
         uint shareAmount;
+    }
+
+    /// @notice Inspect given user's unlock request by index
+    function userUnlockRequests(address owner, uint256 index) external view returns (UnlockRequest memory) {
+        return requests[owner][index];
     }
 
     /// NOTE: Using Benqi sAVAX as example of a Vault with 15d cooldown period
@@ -96,15 +111,6 @@ contract BenqiERC4626Staking is ERC4626 {
     function cooldownPeriod() external view returns (uint256) {
         /// @dev block amount of needed to pass for successfull withdraw
         return sAVAX.cooldownPeriod();
-    }
-
-    function cooldownCheck(uint256 amount, address owner) internal view {
-        uint len = sAVAX.getUnlockRequestCount(owner);
-        for (uint256 i = 0; i < len; i++) {
-            UnlockRequest memory request = requests[owner][i];
-            require(request.startedAt + sAVAX.cooldownPeriod() <= block.timestamp, "NOT_UNLOCKED");
-            require(amount >= request.shareAmount, "NOT_UNLOCKED");
-        }
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -177,30 +183,14 @@ contract BenqiERC4626Staking is ERC4626 {
         emit Deposit(msg.sender, receiver_, assets, shares_);
     }
 
-    /// NOTE: Using Benqi sAVAX as example of a Vault with 15d cooldown period
+    /// @notice Caller needs to transfer shares of this vault to this contract for release of underlying shares to sAVAX
     /// NOTE: https://snowtrace.io/address/0x0ce7f620eb645a4fbf688a1c1937bc6cb0cbdd29#code (sAVAX)
-    /// NOTE: Notice, this requires additional logic on FORM level itself
-    /// NOTE: Owner first submits request for unlock and only after 15d can withdraw
-    function requestWithdraw(uint shareAmount) external {
-        address owner = msg.sender;
-        sAVAX.requestUnlock(shareAmount);        
-        requests[owner].push(
-            UnlockRequest({
-                startedAt: block.timestamp,
-                shareAmount: shareAmount
-            })
-        );
-    }
-
-    /// @notice Withdraw amount of ETH represented by stEth / ERC4626-stEth. Output token is stEth.
-    function withdraw(
-        uint256 assets_,
-        address receiver_,
-        address owner_
-    ) public override assetsUnlocked(assets_, owner_) returns (uint256 shares) {
-        /// @dev In base implementation, previeWithdraw allows to get sAvax amount to withdraw for virtual amount from convertToAssets
+    /// FIXME: For SuperForm-core. It will need to transfer THIS vault's token to this contract (for lock-up)
+    function requestWithdraw(uint256 assets_, address owner_) external returns (uint256 shares) {       
+        
         shares = previewWithdraw(assets_);
 
+        /// @dev Only owner or allowed by owner can request withdraw. Allowance is for this Vault's token.
         if (msg.sender != owner_) {
             uint256 allowed = allowance[owner_][msg.sender];
 
@@ -208,7 +198,61 @@ contract BenqiERC4626Staking is ERC4626 {
                 allowance[owner_][msg.sender] = allowed - shares;
         }
 
-        _burn(owner_, shares);
+        /// @dev Requires user to "lock" his wsAVAX (token of address(this)) for the duration of the cooldown period
+        /// NOTE: Vault's balance will now have shares of this vault token
+        wsAVAX.safeTransferFrom(owner_, address(this), shares);
+
+        /// @dev Burns shares
+        /// cancel request to re-mint amount of shares? 
+        // _burn(owner_, shares);
+
+        /// @dev Approve sAVAX to actual sAVAX shares
+        sAvaxAsset.safeApprove(address(sAVAX), shares);
+
+        /// @dev Transfers shares to sAVAX, sAVAX will burn them after cooldown period
+        sAVAX.requestUnlock(shares);
+
+        /// @dev Internal tracking of withdraw/redeem requests routed through this vault to sAVAX
+        requestId++;
+        requests[owner_].push(
+            UnlockRequest({
+                id: requestId,
+                startedAt: block.timestamp,
+                shareAmount: shares
+            })
+        );
+    }
+
+    /// FIXME: This loop may not finish if user has more than 1 request and one of requests fails on require
+    function cooldownCheck(uint256 amount, address owner) internal view {
+        uint len = requests[owner].length;
+        for (uint256 i = 0; i < len; i++) {
+            UnlockRequest memory request = requests[owner][i];
+            require(request.startedAt + sAVAX.cooldownPeriod() <= block.timestamp, "NOT_UNLOCKED");
+            require(amount >= request.shareAmount, "NOT_UNLOCKED");
+        }
+    }
+
+    /// @notice Withdraw amount of ETH represented by stEth / ERC4626-stEth. Output token is stEth.
+    function withdraw(
+        uint256 assets_,
+        address receiver_,
+        address owner_
+    ) public override returns (uint256 shares) {
+        /// @dev In base implementation, previeWithdraw allows to get sAvax amount to withdraw for virtual amount from convertToAssets
+        shares = previewWithdraw(assets_);
+
+        if (msg.sender != owner_) {
+            uint256 allowed = requestsAllowed[owner_][msg.sender];
+
+            if (allowed != type(uint256).max)
+                requestsAllowed[owner_][msg.sender] = allowed - shares;
+        }
+
+        cooldownCheck(shares, owner_);
+
+        /// FIXME: AVAX operates on msg.sender. We need to track total of unlockIds for each user to redeem only that amount 
+        sAVAX.redeem(1);
 
         emit Withdraw(msg.sender, receiver_, owner_, assets_, shares);
 

--- a/src/benqi/README.md
+++ b/src/benqi/README.md
@@ -12,6 +12,7 @@
 
  Timelock TODO:
 
- - requestWithdraw() / cancelWithdraw() logic
- - Internal tracking of requested withdrawals
- - Redemption mechanism
+ - requestWithdraw() (done) / cancelWithdraw() (todo) logic
+ - Internal tracking of requested withdrawals (done)
+ - Redemption mechanism (done)
+ - Testing

--- a/src/benqi/README.md
+++ b/src/benqi/README.md
@@ -9,3 +9,9 @@
 # Future Works
 
  Extend `BenqiERC4626Staking.sol` with a combined Timelock and unstake capability, allowing to exit from the Vault to AVAX token with yield accrued directly.
+
+ Timelock TODO:
+
+ - requestWithdraw() / cancelWithdraw() logic
+ - Internal tracking of requested withdrawals
+ - Redemption mechanism

--- a/src/benqi/interfaces/IStakedAvax.sol
+++ b/src/benqi/interfaces/IStakedAvax.sol
@@ -2,6 +2,14 @@
 pragma solidity 0.8.19;
 
 interface IStakedAvax {
+
+    struct UnlockRequest {
+        // The timestamp at which the `shareAmount` was requested to be unlocked
+        uint startedAt;
+        // The amount of shares to burn
+        uint shareAmount;
+    }
+
     function getSharesByPooledAvax(uint256 avaxAmount)
         external
         view
@@ -17,4 +25,24 @@ interface IStakedAvax {
     function balanceOf(address) external view returns (uint256);
 
     function submit() external payable returns (uint256);
+
+    /// NOTE: Using Benqi sAVAX as example of a Vault with 15d cooldown period
+    /// NOTE: https://snowtrace.io/address/0x0ce7f620eb645a4fbf688a1c1937bc6cb0cbdd29#code (sAVAX)
+    /// NOTE: Notice, this requires additional logic on FORM level itself
+    /// NOTE: Owner first submits request for unlock and only after 15d can withdraw
+    function requestUnlock(uint shareAmount) external;
+
+    /// NOTE: Using Benqi sAVAX as example of a Vault with 15d cooldown period
+    /// NOTE: Useful for API to keep track of when user can withdraw
+    function cooldownPeriod() external view returns (uint256);
+
+    /// NOTE: Using Benqi sAVAX as example of a Vault with 15d cooldown period
+    function userUnlockRequests(address owner, uint256 index) external view returns (UnlockRequest memory);
+
+    /**
+     * @notice Get the number of active unlock requests by user
+     * @param user User address
+     */
+    function getUnlockRequestCount(address user) external view returns (uint);
+
 }

--- a/src/benqi/interfaces/IStakedAvax.sol
+++ b/src/benqi/interfaces/IStakedAvax.sol
@@ -26,6 +26,10 @@ interface IStakedAvax {
 
     function submit() external payable returns (uint256);
 
+    function redeem(uint unlockIndex) external;
+
+    function redeemOverdueShares(uint unlockIndex) external;
+
     /// NOTE: Using Benqi sAVAX as example of a Vault with 15d cooldown period
     /// NOTE: https://snowtrace.io/address/0x0ce7f620eb645a4fbf688a1c1937bc6cb0cbdd29#code (sAVAX)
     /// NOTE: Notice, this requires additional logic on FORM level itself

--- a/src/benqi/interfaces/IStakedAvax.sol
+++ b/src/benqi/interfaces/IStakedAvax.sol
@@ -40,6 +40,8 @@ interface IStakedAvax {
     /// NOTE: Useful for API to keep track of when user can withdraw
     function cooldownPeriod() external view returns (uint256);
 
+    function redeemPeriod() external view returns (uint256);
+
     /// NOTE: Using Benqi sAVAX as example of a Vault with 15d cooldown period
     function userUnlockRequests(address owner, uint256 index) external view returns (UnlockRequest memory);
 


### PR DESCRIPTION
**WIP!**

Existing Benqi wrapper doesn't support withdraw/redeem operations to AVAX. Functionality that's supported by the original, underlying to the wrapper sAVAX Vault. We add unlock requests management and necessary validation on ERC4626 wrapper for sAVAX level with the goal of fully supporting whole of the existing Benqi sAVAX flow.

TODO:

- Management of ERC4626 level UnlockRequests (multiple requests made by users and delegated to the wrapper itself)
- Tests